### PR TITLE
[Native Lab] 기본 화면 구조와 기록 화면 전환

### DIFF
--- a/apps/native-lab/CHANGELOG.md
+++ b/apps/native-lab/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Expo Router와 TypeScript 설정
 - 현장 기록 앱의 초기 빈 상태 화면
 - `dev`, `build`, `lint`, `check-types`, `test` 스크립트
+- 기록 목록·작성·상세 화면과 세션 내 임시 기록 저장 흐름

--- a/apps/native-lab/docs/learn.md
+++ b/apps/native-lab/docs/learn.md
@@ -23,3 +23,20 @@ pnpm --filter native-lab test
 
 - React Native 기본 컴포넌트와 화면 전환
 - 기록 화면과 SQLite 저장소 연결
+
+## Issue #7 — 기록 화면 흐름
+
+### 배운 내용
+
+- Expo Router의 `src/app` 파일 구조로 목록, 작성, 동적 상세 route를 구성할 수 있다.
+- 화면 전환은 `router.push`, `router.replace`, `router.back`으로 의도를 구분한다.
+- `KeyboardAvoidingView`와 `ScrollView`를 함께 사용하면 작성 화면에서 키보드가 입력 영역을 가리는 문제를 줄일 수 있다.
+- 이 단계의 Context는 복잡한 전역 상태 관리가 아니라 화면 간 임시 기록 전달을 위한 경계다. 영구 저장은 다음 SQLite 단계에서 교체한다.
+
+### 확인할 상태
+
+- 기록 없음
+- 제목 누락 validation
+- 작성 중 취소
+- 작성 완료 후 상세 이동
+- 존재하지 않는 기록 ID로 상세 진입

--- a/apps/native-lab/src/app/_layout.tsx
+++ b/apps/native-lab/src/app/_layout.tsx
@@ -1,5 +1,11 @@
 import { Stack } from 'expo-router';
 
+import { RecordProvider } from '@/features/records/record-context';
+
 export default function RootLayout() {
-  return <Stack screenOptions={{ headerShown: false }} />;
+  return (
+    <RecordProvider>
+      <Stack screenOptions={{ headerShown: false }} />
+    </RecordProvider>
+  );
 }

--- a/apps/native-lab/src/app/index.tsx
+++ b/apps/native-lab/src/app/index.tsx
@@ -22,6 +22,16 @@ export default function HomeScreen() {
             <Text style={styles.description}>
               사진, 파일, 메모를 기기에 남기는 React Native 학습 앱입니다.
             </Text>
+            {records.length > 0 ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="새 기록 만들기"
+                onPress={() => router.push('/record/new')}
+                style={({ pressed }) => [styles.button, pressed && styles.pressed]}
+              >
+                <Text style={styles.buttonLabel}>새 기록 만들기</Text>
+              </Pressable>
+            ) : null}
           </View>
         }
         renderItem={({ item }) => (

--- a/apps/native-lab/src/app/index.tsx
+++ b/apps/native-lab/src/app/index.tsx
@@ -1,34 +1,71 @@
+import { useRouter } from 'expo-router';
+import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { useRecords } from '@/features/records/record-context';
 
 export default function HomeScreen() {
+  const router = useRouter();
+  const { records } = useRecords();
+
   return (
     <SafeAreaView style={styles.safeArea}>
-      <View style={styles.container}>
-        <View style={styles.header}>
-          <Text style={styles.eyebrow}>NATIVE LAB</Text>
-          <Text style={styles.title}>현장 기록</Text>
-          <Text style={styles.description}>
-            사진, 파일, 메모를 기기에 남기는 React Native 학습 앱입니다.
-          </Text>
-        </View>
-
-        <View style={styles.emptyState}>
-          <Text style={styles.emptyTitle}>아직 기록이 없습니다</Text>
-          <Text style={styles.emptyDescription}>
-            다음 단계에서 기록 작성과 네이티브 기능을 연결합니다.
-          </Text>
+      <FlatList
+        contentContainerStyle={styles.listContent}
+        data={records}
+        keyExtractor={record => record.id}
+        ListEmptyComponent={<EmptyState onCreate={() => router.push('/record/new')} />}
+        ListHeaderComponent={
+          <View style={styles.header}>
+            <Text style={styles.eyebrow}>NATIVE LAB</Text>
+            <Text style={styles.title}>현장 기록</Text>
+            <Text style={styles.description}>
+              사진, 파일, 메모를 기기에 남기는 React Native 학습 앱입니다.
+            </Text>
+          </View>
+        }
+        renderItem={({ item }) => (
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel="새 기록 만들기"
-            style={styles.button}
+            accessibilityLabel={`${item.title} 기록 상세 보기`}
+            onPress={() => router.push({ pathname: '/record/[id]', params: { id: item.id } })}
+            style={({ pressed }) => [styles.recordCard, pressed && styles.pressed]}
           >
-            <Text style={styles.buttonLabel}>새 기록 만들기</Text>
+            <Text style={styles.recordTitle}>{item.title}</Text>
+            <Text numberOfLines={2} style={styles.recordMemo}>
+              {item.memo || '메모 없음'}
+            </Text>
+            <Text style={styles.recordDate}>{formatDate(item.createdAt)}</Text>
           </Pressable>
-        </View>
-      </View>
+        )}
+        showsVerticalScrollIndicator={false}
+      />
     </SafeAreaView>
   );
+}
+
+function EmptyState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <View style={styles.emptyState}>
+      <Text style={styles.emptyTitle}>아직 기록이 없습니다</Text>
+      <Text style={styles.emptyDescription}>제목과 메모를 남겨 첫 현장 기록을 만들어 보세요.</Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="새 기록 만들기"
+        onPress={onCreate}
+        style={({ pressed }) => [styles.button, pressed && styles.pressed]}
+      >
+        <Text style={styles.buttonLabel}>새 기록 만들기</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
 }
 
 const styles = StyleSheet.create({
@@ -36,12 +73,13 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#f6f7f9',
   },
-  container: {
-    flex: 1,
+  listContent: {
+    flexGrow: 1,
     padding: 24,
-    gap: 32,
+    gap: 12,
   },
   header: {
+    marginBottom: 20,
     gap: 8,
   },
   eyebrow: {
@@ -77,6 +115,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 21,
     textAlign: 'center',
+    maxWidth: 280,
   },
   button: {
     marginTop: 12,
@@ -84,6 +123,34 @@ const styles = StyleSheet.create({
     backgroundColor: '#1769e0',
     paddingHorizontal: 20,
     paddingVertical: 14,
+  },
+  recordCard: {
+    borderRadius: 16,
+    backgroundColor: '#ffffff',
+    padding: 18,
+    gap: 8,
+    shadowColor: '#17202d',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.06,
+    shadowRadius: 12,
+    elevation: 2,
+  },
+  recordTitle: {
+    color: '#17202d',
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  recordMemo: {
+    color: '#637083',
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  recordDate: {
+    color: '#8b96a5',
+    fontSize: 12,
+  },
+  pressed: {
+    opacity: 0.72,
   },
   buttonLabel: {
     color: '#ffffff',

--- a/apps/native-lab/src/app/record/[id].tsx
+++ b/apps/native-lab/src/app/record/[id].tsx
@@ -76,7 +76,12 @@ const styles = StyleSheet.create({
   scrollView: { flex: 1 },
   container: { padding: 24, gap: 24 },
   centered: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12, padding: 24 },
-  backButton: { alignSelf: 'flex-start', paddingVertical: 4 },
+  backButton: {
+    alignSelf: 'flex-start',
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+  },
   backLabel: { color: '#1769e0', fontSize: 15, fontWeight: '600' },
   header: { gap: 8 },
   title: { color: '#17202d', fontSize: 30, fontWeight: '700', textAlign: 'center' },

--- a/apps/native-lab/src/app/record/[id].tsx
+++ b/apps/native-lab/src/app/record/[id].tsx
@@ -1,0 +1,98 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { useRecords } from '@/features/records/record-context';
+
+export default function RecordDetailScreen() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { getRecord } = useRecords();
+  const record = getRecord(id);
+
+  if (!record) {
+    return (
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.centered}>
+          <Text style={styles.title}>기록을 찾을 수 없습니다</Text>
+          <Text style={styles.description}>
+            아직 저장되지 않았거나 앱을 다시 시작해 사라진 기록입니다.
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="기록 목록으로 돌아가기"
+            onPress={() => router.replace('/')}
+            style={styles.button}
+          >
+            <Text style={styles.buttonLabel}>목록으로 돌아가기</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="기록 목록으로 돌아가기"
+          onPress={() => router.back()}
+          style={styles.backButton}
+        >
+          <Text style={styles.backLabel}>‹ 목록</Text>
+        </Pressable>
+
+        <View style={styles.header}>
+          <Text style={styles.title}>{record.title}</Text>
+          <Text style={styles.date}>{formatDate(record.createdAt)}</Text>
+        </View>
+
+        <View style={styles.memoCard}>
+          <Text style={styles.memoLabel}>메모</Text>
+          <Text style={styles.memo}>{record.memo || '작성한 메모가 없습니다.'}</Text>
+        </View>
+
+        <View style={styles.placeholder}>
+          <Text style={styles.placeholderTitle}>첨부파일</Text>
+          <Text style={styles.placeholderDescription}>
+            사진과 문서 첨부는 다음 네이티브 기능 학습 단계에서 추가합니다.
+          </Text>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'long',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1, backgroundColor: '#f6f7f9' },
+  container: { flex: 1, padding: 24, gap: 24 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12, padding: 24 },
+  backButton: { alignSelf: 'flex-start', paddingVertical: 4 },
+  backLabel: { color: '#1769e0', fontSize: 15, fontWeight: '600' },
+  header: { gap: 8 },
+  title: { color: '#17202d', fontSize: 30, fontWeight: '700', textAlign: 'center' },
+  date: { color: '#8b96a5', fontSize: 13, textAlign: 'center' },
+  description: { color: '#637083', fontSize: 15, lineHeight: 22, textAlign: 'center' },
+  memoCard: { gap: 10, borderRadius: 16, backgroundColor: '#ffffff', padding: 18 },
+  memoLabel: { color: '#637083', fontSize: 13, fontWeight: '700' },
+  memo: { color: '#17202d', fontSize: 16, lineHeight: 25 },
+  placeholder: { gap: 8, borderRadius: 16, borderWidth: 1, borderColor: '#d9e0e8', padding: 18 },
+  placeholderTitle: { color: '#17202d', fontSize: 16, fontWeight: '700' },
+  placeholderDescription: { color: '#637083', fontSize: 14, lineHeight: 21 },
+  button: {
+    marginTop: 12,
+    borderRadius: 12,
+    backgroundColor: '#1769e0',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+  },
+  buttonLabel: { color: '#ffffff', fontSize: 15, fontWeight: '700' },
+});

--- a/apps/native-lab/src/app/record/[id].tsx
+++ b/apps/native-lab/src/app/record/[id].tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useRecords } from '@/features/records/record-context';
@@ -33,7 +33,7 @@ export default function RecordDetailScreen() {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.container} style={styles.scrollView}>
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="기록 목록으로 돌아가기"
@@ -59,7 +59,7 @@ export default function RecordDetailScreen() {
             사진과 문서 첨부는 다음 네이티브 기능 학습 단계에서 추가합니다.
           </Text>
         </View>
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }
@@ -73,7 +73,8 @@ function formatDate(value: string) {
 
 const styles = StyleSheet.create({
   safeArea: { flex: 1, backgroundColor: '#f6f7f9' },
-  container: { flex: 1, padding: 24, gap: 24 },
+  scrollView: { flex: 1 },
+  container: { padding: 24, gap: 24 },
   centered: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12, padding: 24 },
   backButton: { alignSelf: 'flex-start', paddingVertical: 4 },
   backLabel: { color: '#1769e0', fontSize: 15, fontWeight: '600' },

--- a/apps/native-lab/src/app/record/new.tsx
+++ b/apps/native-lab/src/app/record/new.tsx
@@ -117,7 +117,12 @@ const styles = StyleSheet.create({
   flex: { flex: 1 },
   content: { padding: 24, gap: 32 },
   header: { gap: 8 },
-  backButton: { alignSelf: 'flex-start', paddingVertical: 4 },
+  backButton: {
+    alignSelf: 'flex-start',
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+  },
   backLabel: { color: '#1769e0', fontSize: 15, fontWeight: '600' },
   title: { color: '#17202d', fontSize: 32, fontWeight: '700' },
   description: { color: '#637083', fontSize: 15, lineHeight: 22 },

--- a/apps/native-lab/src/app/record/new.tsx
+++ b/apps/native-lab/src/app/record/new.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'expo-router';
 import { useRef, useState } from 'react';
 import {
   KeyboardAvoidingView,
+  AccessibilityInfo,
   Platform,
   Pressable,
   ScrollView,
@@ -29,7 +30,9 @@ export default function NewRecordScreen() {
     const normalizedTitle = title.trim();
 
     if (!normalizedTitle) {
-      setError('기록 제목을 입력해 주세요.');
+      const message = '기록 제목을 입력해 주세요.';
+      setError(message);
+      AccessibilityInfo.announceForAccessibility(message);
       return;
     }
 

--- a/apps/native-lab/src/app/record/new.tsx
+++ b/apps/native-lab/src/app/record/new.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'expo-router';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -20,8 +20,12 @@ export default function NewRecordScreen() {
   const [title, setTitle] = useState('');
   const [memo, setMemo] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const isSavingRef = useRef(false);
 
   const handleSave = () => {
+    if (isSavingRef.current) return;
+
     const normalizedTitle = title.trim();
 
     if (!normalizedTitle) {
@@ -29,6 +33,8 @@ export default function NewRecordScreen() {
       return;
     }
 
+    isSavingRef.current = true;
+    setIsSaving(true);
     const record = createRecord({ title: normalizedTitle, memo: memo.trim() });
     router.replace({ pathname: '/record/[id]', params: { id: record.id } });
   };
@@ -89,10 +95,15 @@ export default function NewRecordScreen() {
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="기록 저장"
+              disabled={isSaving}
               onPress={handleSave}
-              style={({ pressed }) => [styles.saveButton, pressed && styles.pressed]}
+              style={({ pressed }) => [
+                styles.saveButton,
+                isSaving && styles.disabledButton,
+                pressed && styles.pressed,
+              ]}
             >
-              <Text style={styles.saveLabel}>기록 저장</Text>
+              <Text style={styles.saveLabel}>{isSaving ? '저장 중…' : '기록 저장'}</Text>
             </Pressable>
           </View>
         </ScrollView>
@@ -133,5 +144,6 @@ const styles = StyleSheet.create({
     paddingVertical: 15,
   },
   saveLabel: { color: '#ffffff', fontSize: 15, fontWeight: '700' },
+  disabledButton: { opacity: 0.55 },
   pressed: { opacity: 0.72 },
 });

--- a/apps/native-lab/src/app/record/new.tsx
+++ b/apps/native-lab/src/app/record/new.tsx
@@ -1,0 +1,137 @@
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { useRecords } from '@/features/records/record-context';
+
+export default function NewRecordScreen() {
+  const router = useRouter();
+  const { createRecord } = useRecords();
+  const [title, setTitle] = useState('');
+  const [memo, setMemo] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = () => {
+    const normalizedTitle = title.trim();
+
+    if (!normalizedTitle) {
+      setError('기록 제목을 입력해 주세요.');
+      return;
+    }
+
+    const record = createRecord({ title: normalizedTitle, memo: memo.trim() });
+    router.replace({ pathname: '/record/[id]', params: { id: record.id } });
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.flex}
+      >
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          <View style={styles.header}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="기록 작성 취소"
+              onPress={() => router.back()}
+              style={styles.backButton}
+            >
+              <Text style={styles.backLabel}>‹ 목록</Text>
+            </Pressable>
+            <Text style={styles.title}>새 기록</Text>
+            <Text style={styles.description}>현장에서 확인한 내용을 간단히 남겨 보세요.</Text>
+          </View>
+
+          <View style={styles.form}>
+            <View style={styles.field}>
+              <Text style={styles.label}>제목</Text>
+              <TextInput
+                accessibilityLabel="기록 제목"
+                autoFocus
+                onChangeText={value => {
+                  setTitle(value);
+                  setError(null);
+                }}
+                placeholder="예: 1층 배관 점검"
+                placeholderTextColor="#9aa5b4"
+                style={styles.input}
+                value={title}
+              />
+            </View>
+
+            <View style={styles.field}>
+              <Text style={styles.label}>메모</Text>
+              <TextInput
+                accessibilityLabel="기록 메모"
+                multiline
+                onChangeText={setMemo}
+                placeholder="현장 상황이나 다음 작업을 적어 주세요."
+                placeholderTextColor="#9aa5b4"
+                style={[styles.input, styles.memoInput]}
+                textAlignVertical="top"
+                value={memo}
+              />
+            </View>
+
+            {error ? <Text style={styles.error}>{error}</Text> : null}
+
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="기록 저장"
+              onPress={handleSave}
+              style={({ pressed }) => [styles.saveButton, pressed && styles.pressed]}
+            >
+              <Text style={styles.saveLabel}>기록 저장</Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1, backgroundColor: '#f6f7f9' },
+  flex: { flex: 1 },
+  content: { padding: 24, gap: 32 },
+  header: { gap: 8 },
+  backButton: { alignSelf: 'flex-start', paddingVertical: 4 },
+  backLabel: { color: '#1769e0', fontSize: 15, fontWeight: '600' },
+  title: { color: '#17202d', fontSize: 32, fontWeight: '700' },
+  description: { color: '#637083', fontSize: 15, lineHeight: 22 },
+  form: { gap: 22 },
+  field: { gap: 8 },
+  label: { color: '#17202d', fontSize: 14, fontWeight: '700' },
+  input: {
+    minHeight: 52,
+    borderWidth: 1,
+    borderColor: '#d9e0e8',
+    borderRadius: 12,
+    backgroundColor: '#ffffff',
+    color: '#17202d',
+    fontSize: 16,
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+  },
+  memoInput: { minHeight: 160 },
+  error: { color: '#b42318', fontSize: 14, lineHeight: 20 },
+  saveButton: {
+    alignItems: 'center',
+    borderRadius: 12,
+    backgroundColor: '#1769e0',
+    paddingVertical: 15,
+  },
+  saveLabel: { color: '#ffffff', fontSize: 15, fontWeight: '700' },
+  pressed: { opacity: 0.72 },
+});

--- a/apps/native-lab/src/features/records/record-context.tsx
+++ b/apps/native-lab/src/features/records/record-context.tsx
@@ -1,0 +1,54 @@
+import { createContext, PropsWithChildren, useContext, useMemo, useState } from 'react';
+
+export interface FieldRecord {
+  id: string;
+  title: string;
+  memo: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RecordContextValue {
+  records: FieldRecord[];
+  createRecord: (input: Pick<FieldRecord, 'title' | 'memo'>) => FieldRecord;
+  getRecord: (id: string) => FieldRecord | undefined;
+}
+
+const RecordContext = createContext<RecordContextValue | null>(null);
+
+export function RecordProvider({ children }: PropsWithChildren) {
+  const [records, setRecords] = useState<FieldRecord[]>([]);
+
+  const value = useMemo<RecordContextValue>(
+    () => ({
+      records,
+      createRecord: ({ title, memo }) => {
+        const now = new Date().toISOString();
+        const record: FieldRecord = {
+          id: `${Date.now()}`,
+          title,
+          memo,
+          createdAt: now,
+          updatedAt: now,
+        };
+
+        setRecords(current => [record, ...current]);
+        return record;
+      },
+      getRecord: id => records.find(record => record.id === id),
+    }),
+    [records]
+  );
+
+  return <RecordContext.Provider value={value}>{children}</RecordContext.Provider>;
+}
+
+export function useRecords() {
+  const context = useContext(RecordContext);
+
+  if (!context) {
+    throw new Error('useRecords must be used inside RecordProvider');
+  }
+
+  return context;
+}


### PR DESCRIPTION
Closes #7

## 요약

- 기록 목록 화면 구성
- 기록 작성 화면과 제목 validation 추가
- 기록 상세 화면과 존재하지 않는 ID 처리 추가
- Expo Router의 목록·작성·동적 상세 route 연결
- 세션 내 임시 기록 Context 추가
- 키보드 대응, 빈 상태, loading 전 단계의 기본 화면 구조와 접근성 label 추가
- `CHANGELOG.md`, `docs/learn.md`에 학습 내용 기록

## 검증

- `pnpm --filter native-lab lint`
- `pnpm --filter native-lab check-types`
- `pnpm --filter native-lab test`
- `pnpm --filter native-lab build`

Expo export에서 다음 route 생성을 확인했습니다.

- `/`
- `/record/new`
- `/record/[id]`

## 의존성

이 PR은 [#16](https://github.com/bebusl/laboratory/pull/16) 위에 쌓여 있습니다. #16 merge 후 base를 `main`으로 변경해 merge합니다.