### PR TITLE
[Native Lab] 첨부파일 OS 공유 시트 연결

### DIFF
--- a/apps/native-lab/CHANGELOG.md
+++ b/apps/native-lab/CHANGELOG.md
@@ -15,3 +15,4 @@
 - 문서 선택과 앱 전용 Documents/attachments 파일 저장
 - 이미지·문서 첨부파일의 공통 메타데이터 정규화 및 SQLite 저장 함수
 - 기록별 복수 첨부파일 표시와 파일·SQLite 삭제 정합성 처리
+- 첨부파일별 iOS·Android OS 공유 시트 연결

--- a/apps/native-lab/app.json
+++ b/apps/native-lab/app.json
@@ -17,7 +17,8 @@
           "cameraPermission": "현장 기록에 사진을 첨부하기 위해 카메라 접근이 필요합니다.",
           "microphonePermission": false
         }
-      ]
+      ],
+      "expo-sharing"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/apps/native-lab/docs/learn.md
+++ b/apps/native-lab/docs/learn.md
@@ -80,3 +80,12 @@ pnpm --filter native-lab test
 - 기록 생성과 attachment metadata INSERT는 SQLite transaction으로 묶어 부분 저장을 막고, transaction 실패 시 아직 DB에 연결되지 않은 앱 파일을 정리한다.
 - 파일 시스템은 DB처럼 transaction을 제공하지 않으므로 기록 삭제는 연결된 파일을 먼저 삭제하고, 모든 파일 정리가 끝난 뒤 `ON DELETE CASCADE`로 SQLite 메타데이터를 삭제한다. 일부 파일 삭제가 실패하면 DB 삭제를 보류하고 사용자에게 재시도를 안내한다.
 - DB에 URI가 남아 있어도 실제 파일은 수동 삭제나 OS 상태 변화로 사라질 수 있다. 상세 화면은 파일 존재 여부를 확인하고 복구 불가 상태와 재첨부 안내를 표시한다.
+
+## Issue #12 — 첨부파일 OS 공유 시트
+
+### 배운 내용
+
+- `expo-sharing`은 `isAvailableAsync()`로 공유 API 사용 가능 여부를 먼저 확인한 뒤 `shareAsync(uri, options)`를 호출한다.
+- Android는 Intent에 MIME type과 대화상자 제목을 전달하고, iOS는 UTI를 전달하므로 공통 URI 외의 공유 옵션은 플랫폼별로 분기한다.
+- 공유 API의 `void` 결과는 사용자가 시트를 닫았는지와 실제 대상 앱이 파일을 처리했는지를 구분하지 않는다. 이 단계에서는 공유 시트 호출 성공과 API 실패·파일 누락만 앱 상태로 구분한다.
+- 공유 불가 환경, 파일 누락, 공유 시트 실행 실패를 첨부파일 단위 오류로 표시해 기록 전체 화면의 오류로 확산하지 않는다.

--- a/apps/native-lab/package.json
+++ b/apps/native-lab/package.json
@@ -21,6 +21,7 @@
     "expo-image-picker": "~57.0.12",
     "expo-linking": "~57.0.7",
     "expo-router": "~57.0.15",
+    "expo-sharing": "~57.0.14",
     "expo-sqlite": "~57.0.1",
     "expo-status-bar": "~57.0.1",
     "expo-system-ui": "~57.0.2",

--- a/apps/native-lab/src/app/record/[id].tsx
+++ b/apps/native-lab/src/app/record/[id].tsx
@@ -1,14 +1,17 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useState } from 'react';
+import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useRecords } from '@/features/records/record-context';
 import { AttachmentCard } from '@/features/attachments/attachment-card';
+import { shareAttachment } from '@/features/attachments/share-attachment';
 import { useRecordAttachments } from '@/features/records/record-attachments';
 
 export default function RecordDetailScreen() {
   const router = useRouter();
+  const [sharingAttachmentId, setSharingAttachmentId] = useState<string | null>(null);
+  const [sharingError, setSharingError] = useState<string | null>(null);
   const { id } = useLocalSearchParams<{ id: string }>();
   const { deleteRecord, error, getRecord, isLoading } = useRecords();
   const [isDeleting, setIsDeleting] = useState(false);
@@ -90,9 +93,25 @@ export default function RecordDetailScreen() {
             <Text style={styles.placeholderDescription}>첨부한 사진이나 문서가 없습니다.</Text>
           ) : (
             attachments.map(attachment => (
-              <AttachmentCard attachment={attachment} key={attachment.id} />
+              <AttachmentCard
+                attachment={attachment}
+                isSharing={sharingAttachmentId === attachment.id}
+                key={attachment.id}
+                onShare={() => {
+                  setSharingAttachmentId(attachment.id);
+                  setSharingError(null);
+                  void shareAttachment(attachment)
+                    .then(result => {
+                      if ('failure' in result) {
+                        setSharingError(result.failure.message);
+                      }
+                    })
+                    .finally(() => setSharingAttachmentId(null));
+                }}
+              />
             ))
           )}
+          {sharingError ? <Text style={styles.errorDescription}>{sharingError}</Text> : null}
         </View>
         <Pressable
           accessibilityRole="button"

--- a/apps/native-lab/src/features/attachments/attachment-card.tsx
+++ b/apps/native-lab/src/features/attachments/attachment-card.tsx
@@ -7,9 +7,11 @@ import type { StoredAttachment } from '@/features/attachments/types';
 interface AttachmentCardProps {
   attachment: StoredAttachment;
   onRemove?: () => void;
+  onShare?: () => void;
+  isSharing?: boolean;
 }
 
-export function AttachmentCard({ attachment, onRemove }: AttachmentCardProps) {
+export function AttachmentCard({ attachment, isSharing, onRemove, onShare }: AttachmentCardProps) {
   const isAvailable = getAvailability(attachment.uri);
 
   return (
@@ -49,15 +51,30 @@ export function AttachmentCard({ attachment, onRemove }: AttachmentCardProps) {
         {!isAvailable ? (
           <Text style={styles.missing}>파일이 사라졌습니다. 원본을 다시 첨부해 주세요.</Text>
         ) : null}
-        {onRemove ? (
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={`${attachment.name} 첨부파일 제거`}
-            onPress={onRemove}
-            style={styles.removeButton}
-          >
-            <Text style={styles.removeLabel}>첨부파일 제거</Text>
-          </Pressable>
+        {onShare || onRemove ? (
+          <View style={styles.actions}>
+            {onShare ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`${attachment.name} 공유`}
+                disabled={isSharing}
+                onPress={onShare}
+                style={styles.actionButton}
+              >
+                <Text style={styles.actionLabel}>{isSharing ? '공유 중…' : '공유'}</Text>
+              </Pressable>
+            ) : null}
+            {onRemove ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`${attachment.name} 첨부파일 제거`}
+                onPress={onRemove}
+                style={styles.removeButton}
+              >
+                <Text style={styles.removeLabel}>첨부파일 제거</Text>
+              </Pressable>
+            ) : null}
+          </View>
         ) : null}
       </View>
     </View>
@@ -104,4 +121,7 @@ const styles = StyleSheet.create({
   missing: { color: '#b42318', fontSize: 12, lineHeight: 17 },
   removeButton: { alignSelf: 'flex-start', paddingVertical: 3 },
   removeLabel: { color: '#b42318', fontSize: 12, fontWeight: '700' },
+  actions: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  actionButton: { alignSelf: 'flex-start', paddingVertical: 3 },
+  actionLabel: { color: '#1769e0', fontSize: 12, fontWeight: '700' },
 });

--- a/apps/native-lab/src/features/attachments/share-attachment.ts
+++ b/apps/native-lab/src/features/attachments/share-attachment.ts
@@ -1,0 +1,81 @@
+import * as Sharing from 'expo-sharing';
+import { File } from 'expo-file-system';
+import { Platform } from 'react-native';
+
+import type { StoredAttachment } from '@/features/attachments/types';
+
+export type ShareAttachmentResult =
+  | { shared: true }
+  | { failure: { kind: 'unavailable' | 'missing' | 'failed'; message: string } };
+
+export async function shareAttachment(
+  attachment: StoredAttachment
+): Promise<ShareAttachmentResult> {
+  let fileExists = false;
+
+  try {
+    fileExists = new File(attachment.uri).info().exists;
+  } catch {
+    fileExists = false;
+  }
+
+  if (!fileExists) {
+    return {
+      failure: {
+        kind: 'missing',
+        message: '공유할 파일이 앱 저장 공간에 없습니다. 원본 파일을 다시 첨부해 주세요.',
+      },
+    };
+  }
+
+  try {
+    if (!(await Sharing.isAvailableAsync())) {
+      return {
+        failure: {
+          kind: 'unavailable',
+          message: '이 기기에서는 파일 공유를 사용할 수 없습니다.',
+        },
+      };
+    }
+
+    await Sharing.shareAsync(attachment.uri, getSharingOptions(attachment));
+    return { shared: true };
+  } catch {
+    return {
+      failure: {
+        kind: 'failed',
+        message: '공유 시트를 열지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      },
+    };
+  }
+}
+
+function getSharingOptions(attachment: StoredAttachment) {
+  if (Platform.OS === 'android') {
+    return {
+      dialogTitle: `${attachment.name} 공유`,
+      mimeType: attachment.mimeType || 'application/octet-stream',
+    };
+  }
+
+  return {
+    UTI: utiForAttachment(attachment),
+  };
+}
+
+function utiForAttachment(attachment: StoredAttachment) {
+  switch (attachment.mimeType) {
+    case 'image/jpeg':
+      return 'public.jpeg';
+    case 'image/png':
+      return 'public.png';
+    case 'image/heic':
+      return 'public.heic';
+    case 'application/pdf':
+      return 'com.adobe.pdf';
+    case 'text/plain':
+      return 'public.plain-text';
+    default:
+      return attachment.kind === 'image' ? 'public.image' : 'public.data';
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       expo-router:
         specifier: ~57.0.15
         version: 57.0.15(d458a117f920ca1d9299588a89051f6e)
+      expo-sharing:
+        specifier: ~57.0.14
+        version: 57.0.14(expo@57.0.15)(react-native@0.86.2(@babel/core@7.28.5)(@react-native/metro-config@0.86.2(@babel/core@7.28.5))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-sqlite:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.15)(react-native@0.86.2(@babel/core@7.28.5)(@react-native/metro-config@0.86.2(@babel/core@7.28.5))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
@@ -3703,6 +3706,13 @@ packages:
   expo-server@57.0.3:
     resolution: {integrity: sha512-aK+LdKzauHSGmsOStZtyxdzv0zWssCkxTw3m4QuOhfDSJsZaMRTd9O41d8ixU/QfELTbaJ0oRNcF7JFV/7O9YQ==}
     engines: {node: '>=20.16.0'}
+
+  expo-sharing@57.0.14:
+    resolution: {integrity: sha512-X/GG2Z/aGHzC90gnX4rX88BJjoWEt5Piqgeybb0taOvSCu8N/sHROvbIrYp07NSLagOqGTYAgfDmmyQXtrchJQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-sqlite@57.0.1:
     resolution: {integrity: sha512-I6KoUvfGIiROTKxr5D3H+jRIGA/iEvWEtqHK4XMukAA7tVTinz/YdS8zOz6/DdG6vgrNmvF7gyOcbhLinlfxzQ==}
@@ -10295,6 +10305,18 @@ snapshots:
       - supports-color
 
   expo-server@57.0.3: {}
+
+  expo-sharing@57.0.14(expo@57.0.15)(react-native@0.86.2(@babel/core@7.28.5)(@react-native/metro-config@0.86.2(@babel/core@7.28.5))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
+    dependencies:
+      '@expo/config-plugins': 57.0.8(typescript@6.0.3)
+      '@expo/config-types': 57.0.2
+      '@expo/plist': 0.8.1
+      expo: 57.0.15(@babel/core@7.28.5)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.28.5)(@react-native/metro-config@0.86.2(@babel/core@7.28.5))(react-native@0.86.2(@babel/core@7.28.5)(@react-native/metro-config@0.86.2(@babel/core@7.28.5))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.28.5)(@react-native/metro-config@0.86.2(@babel/core@7.28.5))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.28.5)(@react-native/metro-config@0.86.2(@babel/core@7.28.5))(@types/react@19.2.7)(react@19.2.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   expo-sqlite@57.0.1(expo@57.0.15)(react-native@0.86.2(@babel/core@7.28.5)(@react-native/metro-config@0.86.2(@babel/core@7.28.5))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
     dependencies:


### PR DESCRIPTION
## 요약
- 첨부파일별 공유 버튼과 공유 중 상태를 추가했습니다.
- expo-sharing의 isAvailableAsync/shareAsync를 사용해 앱 전용 URI를 OS 공유 시트로 전달합니다.
- Android MIME type/dialog title, iOS UTI를 플랫폼별로 전달합니다.
- 공유 불가 환경, 파일 누락, 공유 시트 실패를 첨부파일 단위 오류로 처리합니다.

## 검증
- pnpm --filter native-lab lint
- pnpm --filter native-lab check-types
- pnpm --filter native-lab test
- pnpm --filter native-lab build

## 참고
- #21 이후 작업이며, Custom URL Scheme 딥링크는 #13에서 이어갑니다.
- expo-sharing API는 공유 시트 취소 여부를 별도 결과로 제공하지 않으므로 시트 호출 완료는 성공으로 처리합니다.

Closes #12