### PR TITLE
[Native Lab] 오류 처리·접근성·iOS/Android 최종 검증

### DIFF
--- a/apps/native-lab/CHANGELOG.md
+++ b/apps/native-lab/CHANGELOG.md
@@ -18,3 +18,5 @@
 - 첨부파일별 iOS·Android OS 공유 시트 연결
 - `nativelab://record/{id}` 초기·실행 중 딥링크 처리
 - 보조 WebView 화면과 RN↔웹 typed Bridge
+- 권한·파일·WebView 오류 상태와 VoiceOver/TalkBack 안내 보강
+- iOS/Android 네이티브 검증 절차와 플랫폼 차이 문서화

--- a/apps/native-lab/README.md
+++ b/apps/native-lab/README.md
@@ -19,6 +19,21 @@ pnpm --filter native-lab ios
 
 현재 화면은 앱 골격을 확인하기 위한 초기 화면이다. 카메라, 파일, SQLite, 공유, 딥링크, WebView 기능은 각각의 GitHub Issue에서 단계적으로 추가한다.
 
+## 네이티브 기능 확인
+
+권한, 카메라, 사진 보관함, 공유 시트, 딥링크는 iOS 시뮬레이터·실기기와 Android 에뮬레이터·실기기에서 각각 확인한다. Expo Go보다 development build 또는 네이티브 실행 환경에서 custom scheme과 권한 동작을 확인하는 것이 정확하다.
+
+```bash
+pnpm --filter native-lab ios
+pnpm --filter native-lab android
+
+# 실행 중인 시뮬레이터/에뮬레이터에 딥링크 전달
+xcrun simctl openurl booted 'nativelab://record/<record-id>'
+adb shell am start -a android.intent.action.VIEW -d 'nativelab://record/<record-id>'
+```
+
+iOS는 사진 접근의 limited 상태와 sandbox URI를, Android는 `content://` 선택 URI·런타임 권한·system back을 별도로 확인한다. 앱은 선택한 파일을 양쪽 모두 Documents/attachments에 복사한 뒤 해당 URI를 SQLite에 저장한다.
+
 ## 검증
 
 ```bash

--- a/apps/native-lab/docs/learn.md
+++ b/apps/native-lab/docs/learn.md
@@ -110,3 +110,35 @@ pnpm --filter native-lab test
 - `originWhitelist`와 `onShouldStartLoadWithRequest`를 함께 사용해 `about:blank`, Expo 문서, React Native 문서만 WebView 안에서 허용하고 다른 링크는 차단한다.
 - WebView 로딩 시작·완료·오류를 별도 상태로 관리하고, 오류 화면에서 다시 시도할 수 있게 한다.
 - iOS ATS와 Android cleartext 정책 때문에 원격 HTTP 콘텐츠를 운영 수준에서 사용하려면 별도 native 설정이 필요하다. 이번 학습 화면은 inline HTML과 HTTPS allowlist만 사용한다.
+
+## Issue #15 — 오류 처리·접근성·iOS/Android 최종 검증
+
+### 확인한 오류 상태
+
+- 카메라·사진 권한 거부, iOS limited 사진 접근, 문서·사진 선택 취소는 현재 작성 중인 첨부 목록을 유지하면서 기능별 안내를 표시한다.
+- 파일 URI 누락·복사 실패·파일 삭제 실패는 파일 저장/삭제 오류로 변환하고, DB 저장 실패는 기록 저장 오류로 표시한다.
+- 기록 삭제는 실제 파일 정리가 끝나기 전 SQLite cascade를 실행하지 않으며, 일부 삭제 실패 시 재시도할 수 있도록 기록을 유지한다.
+- 공유 불가 환경·공유 파일 누락·공유 시트 실행 실패는 첨부파일 단위 오류로 처리한다.
+- WebView 로딩 오류는 재시도 화면을 제공하고, 알 수 없는 Bridge 메시지와 허용되지 않은 navigation은 무시하거나 차단한다.
+
+### 접근성과 플랫폼 확인 포인트
+
+- 주요 버튼은 `accessibilityRole`과 목적을 설명하는 `accessibilityLabel`을 갖고, 제목·메모 입력창과 저장/삭제 오류는 VoiceOver/TalkBack에서 읽을 수 있는 상태로 둔다.
+- iOS는 Safe Area, swipe-back, camera/photo permission purpose, limited photo access, UTI와 sandbox 파일 URI를 확인한다.
+- Android는 system back, keyboard resize, runtime permission, `content://` URI, MIME type과 Intent 공유를 확인한다.
+- WebView는 inline HTML을 사용하므로 iOS ATS와 Android cleartext 설정을 건드리지 않는다. 원격 링크는 HTTPS allowlist만 허용한다.
+
+### 최종 검증 명령
+
+```bash
+pnpm --filter native-lab lint
+pnpm --filter native-lab check-types
+pnpm --filter native-lab test
+pnpm --filter native-lab build
+pnpm lint
+pnpm check-types
+pnpm test
+pnpm format:check
+```
+
+네이티브 export는 iOS와 Android 모두 완료되었고, 실제 권한·카메라·공유·딥링크는 README의 시뮬레이터/실기기 명령으로 플랫폼별 확인한다.

--- a/apps/native-lab/src/app/record/edit/[id].tsx
+++ b/apps/native-lab/src/app/record/edit/[id].tsx
@@ -123,7 +123,11 @@ function EditRecordForm({ record }: { record: FieldRecord }) {
               />
             </View>
 
-            {formError ? <Text style={styles.error}>{formError}</Text> : null}
+            {formError ? (
+              <Text accessibilityRole="alert" style={styles.error}>
+                {formError}
+              </Text>
+            ) : null}
 
             <Pressable
               accessibilityRole="button"

--- a/apps/native-lab/src/app/record/new.tsx
+++ b/apps/native-lab/src/app/record/new.tsx
@@ -130,7 +130,11 @@ export default function NewRecordScreen() {
               />
             </View>
 
-            {error ? <Text style={styles.error}>{error}</Text> : null}
+            {error ? (
+              <Text accessibilityRole="alert" style={styles.error}>
+                {error}
+              </Text>
+            ) : null}
 
             <Pressable
               accessibilityRole="button"

--- a/apps/native-lab/src/app/webview.tsx
+++ b/apps/native-lab/src/app/webview.tsx
@@ -55,7 +55,9 @@ export default function WebViewLearningScreen() {
       <SafeAreaView style={styles.safeArea}>
         <View style={styles.centered}>
           <Text style={styles.title}>WebView를 열 수 없습니다</Text>
-          <Text style={styles.description}>{error}</Text>
+          <Text accessibilityRole="alert" style={styles.description}>
+            {error}
+          </Text>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="WebView 다시 시도"

--- a/apps/native-lab/src/features/attachments/document-picker.ts
+++ b/apps/native-lab/src/features/attachments/document-picker.ts
@@ -1,6 +1,7 @@
 import * as DocumentPicker from 'expo-document-picker';
 
 import {
+  AttachmentStorageError,
   extensionFromName,
   storeAttachment,
   type AttachmentStorageFailureKind,
@@ -53,8 +54,5 @@ export async function pickAndStoreDocument(): Promise<
 function isStorageFailure(cause: unknown): cause is Error & {
   kind: AttachmentStorageFailureKind;
 } {
-  return (
-    cause instanceof Error &&
-    (cause as Error & { kind?: AttachmentStorageFailureKind }).kind !== undefined
-  );
+  return cause instanceof AttachmentStorageError;
 }

--- a/apps/native-lab/src/features/attachments/file-storage.ts
+++ b/apps/native-lab/src/features/attachments/file-storage.ts
@@ -36,12 +36,13 @@ export async function storeAttachment(source: AttachmentSource): Promise<StoredA
     );
   }
 
-  attachmentDirectory.create({ idempotent: true, intermediates: true });
-
-  const safeName = sanitizeFileName(source.name, source.extension);
-  const destination = new File(attachmentDirectory, `${createStorageId()}-${safeName}`);
+  let destination: File | null = null;
 
   try {
+    attachmentDirectory.create({ idempotent: true, intermediates: true });
+
+    const safeName = sanitizeFileName(source.name, source.extension);
+    destination = new File(attachmentDirectory, `${createStorageId()}-${safeName}`);
     await sourceFile.copy(destination);
     const destinationInfo = destination.info();
 
@@ -58,8 +59,12 @@ export async function storeAttachment(source: AttachmentSource): Promise<StoredA
       uri: destination.uri,
     };
   } catch {
-    if (destination.info().exists) {
-      destination.delete();
+    try {
+      if (destination?.info().exists) {
+        destination.delete();
+      }
+    } catch {
+      // Keep the original copy failure visible. A later cleanup pass can handle the file.
     }
 
     throw new AttachmentStorageError(

--- a/apps/native-lab/src/features/media/image-attachment-picker.tsx
+++ b/apps/native-lab/src/features/media/image-attachment-picker.tsx
@@ -131,7 +131,11 @@ export function ImageAttachmentPicker({ value, onChange }: ImageAttachmentPicker
         </Pressable>
       </View>
 
-      {error ? <Text style={styles.error}>{error}</Text> : null}
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.error}>
+          {error}
+        </Text>
+      ) : null}
       <Text style={styles.hint}>
         선택한 파일은 앱 Documents/attachments에 한 번만 복사하며, 원본 메모리를 읽지 않습니다.
       </Text>

--- a/apps/native-lab/src/features/media/image-picker.ts
+++ b/apps/native-lab/src/features/media/image-picker.ts
@@ -31,20 +31,20 @@ export type ImagePickerFailure =
 export async function captureImage(): Promise<
   { image: SelectedImage } | { canceled: true } | { failure: ImagePickerFailure }
 > {
-  const permission = await ImagePicker.requestCameraPermissionsAsync();
-
-  if (!permission.granted) {
-    return {
-      failure: {
-        kind: 'permission-denied',
-        message: permission.canAskAgain
-          ? '카메라 권한을 허용해야 사진을 촬영할 수 있습니다.'
-          : '카메라 권한이 거부되었습니다. 기기 설정에서 권한을 허용해 주세요.',
-      },
-    };
-  }
-
   try {
+    const permission = await ImagePicker.requestCameraPermissionsAsync();
+
+    if (!permission.granted) {
+      return {
+        failure: {
+          kind: 'permission-denied',
+          message: permission.canAskAgain
+            ? '카메라 권한을 허용해야 사진을 촬영할 수 있습니다.'
+            : '카메라 권한이 거부되었습니다. 기기 설정에서 권한을 허용해 주세요.',
+        },
+      };
+    }
+
     const result = await ImagePicker.launchCameraAsync({
       allowsEditing: false,
       mediaTypes: ['images'],
@@ -64,23 +64,23 @@ export async function captureImage(): Promise<
 export async function pickImageFromLibrary(): Promise<
   { image: SelectedImage } | { canceled: true } | { failure: ImagePickerFailure }
 > {
-  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
-
-  if (!permission.granted) {
-    return {
-      failure: {
-        kind: 'permission-denied',
-        message:
-          permission.accessPrivileges === 'limited'
-            ? '선택된 사진에만 접근할 수 있습니다. 다른 사진을 추가하려면 사진 접근 권한을 변경해 주세요.'
-            : permission.canAskAgain
-              ? '사진 보관함 접근 권한을 허용해야 사진을 선택할 수 있습니다.'
-              : '사진 보관함 권한이 거부되었습니다. 기기 설정에서 권한을 허용해 주세요.',
-      },
-    };
-  }
-
   try {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (!permission.granted) {
+      return {
+        failure: {
+          kind: 'permission-denied',
+          message:
+            permission.accessPrivileges === 'limited'
+              ? '선택된 사진에만 접근할 수 있습니다. 다른 사진을 추가하려면 사진 접근 권한을 변경해 주세요.'
+              : permission.canAskAgain
+                ? '사진 보관함 접근 권한을 허용해야 사진을 선택할 수 있습니다.'
+                : '사진 보관함 권한이 거부되었습니다. 기기 설정에서 권한을 허용해 주세요.',
+        },
+      };
+    }
+
     const result = await ImagePicker.launchImageLibraryAsync({
       allowsEditing: false,
       mediaTypes: ['images'],


### PR DESCRIPTION
## 요약
- 권한 요청 자체의 예외와 선택 취소·제한 접근을 기능별 오류/정상 상태로 처리합니다.
- 파일 복사·삭제 실패와 DB transaction 실패에서 부분 저장/삭제를 줄이고 사용자 안내를 제공합니다.
- 주요 오류 메시지에 접근성 alert 역할을 추가하고 입력·버튼 레이블을 점검했습니다.
- README와 learn 문서에 iOS/Android 차이, native 확인 명령, 최종 검증 명령을 기록했습니다.

## 검증
- pnpm --filter native-lab lint
- pnpm --filter native-lab check-types
- pnpm --filter native-lab test
- pnpm --filter native-lab build

## 참고
- #24 이후 작업입니다.
- 실제 권한·카메라·사진 보관함·공유·딥링크 동작은 iOS/Android 실기기 또는 시뮬레이터에서 README 명령으로 확인합니다.

Closes #15